### PR TITLE
Use the most specific key first when looking up caches

### DIFF
--- a/orb.yaml
+++ b/orb.yaml
@@ -79,8 +79,8 @@ commands:
       - restore_cache:
           name: Restore go module cache
           keys:
-            - '<< parameters.prefix >>-{{ arch }}-go-modules-'
             - '<< parameters.prefix >>-{{ arch }}-go-modules-{{ checksum "go.sum" }}'
+            - '<< parameters.prefix >>-{{ arch }}-go-modules-'
       - run:
           environment:
             GO111MODULE: 'on'


### PR DESCRIPTION
Cache keys are matched in order, so specific should be a better match